### PR TITLE
no longer generating package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,18 @@ The generators should be run in the root of a working folder for your project. T
 
 #### App (Default) Generator
 
-The app generator installs and configures the [grunt tasks](#running-the-grunt-tasks) and other project files (`package.json`, `.jshintrc`, etc) and ensures that required subfolders (like `widgets`) exist.
+The app generator installs and configures the [grunt tasks](#running-the-grunt-tasks) and other project files (.jshintrc, etc) and ensures that required subfolders (like widgets) exist.
 
 1. Navigate into the root folder of your project
-2. Run the generator with `yo esri-appbuilder-js`
-3. Answer the man's questions!
+2. If you haven't already created a package.json file in this folder, run `npm init` (see NOTE below)
+3. Run the generator with `yo esri-appbuilder-js`
+4. Answer the man's questions!
 
 |Prompt|Description|Default|
 |------|-----------|-------|
-|Author|Name of developers or organization for widget manifests|Your Name or Organization
-|Web AppBuilder install root|The root folder where you installed (unzipped) the Web AppBuilder Developer Edition[USER_HOME_FOLDER]/arcgis-web-appbuilder-1.3|
+|Web AppBuilder install root|The root folder where you installed (unzipped) the Web AppBuilder Developer Edition|[USER_HOME_FOLDER]/arcgis-web-appbuilder-1.3|
+
+**NOTE** A package.json file is not *required* but it allows the generator to save your dependencies in case you or other developers need to (re)install them later without running the generator.
 
 #### Widget Generator
 

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -17,7 +17,7 @@ describe('esri-appbuilder-js generator', function () {
       ]);
 
       helpers.mockPrompt(this.app, {
-        'author': 'Tom Wayson',
+        'abort': false,
         'wabRoot': wabRoot
       });
       this.app.options['skip-install'] = true;
@@ -35,19 +35,6 @@ describe('esri-appbuilder-js generator', function () {
       '.editorconfig'
     ];
     helpers.assertFile(expected);
-  });
-
-  describe('when generating package.json', function() {
-    it('sets author name', function() {
-      helpers.assertFileContent('package.json', /"name": "Tom Wayson"/);
-    });
-
-    // TODO: test if package.json has properties
-    it('sets dependencies', function() {
-      helpers.assertFileContent('package.json', /"grunt": "\^0.4.5"/);
-      helpers.assertFileContent('package.json', /"grunt-contrib-watch": "\^0.6.1"/);
-      helpers.assertFileContent('package.json', /"grunt-sync": "\^0.5.1"/);
-    });
   });
 
   describe('when creating gruntfile', function() {

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -62,3 +62,35 @@ describe('esri-appbuilder-js generator', function () {
     });
   });
 });
+
+describe('esri-appbuilder-js abort', function () {
+  before(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.app = helpers.createGenerator('esri-appbuilder-js:app', [
+        '../../app'
+      ]);
+
+      helpers.mockPrompt(this.app, {
+        'abort': true,
+        'wabRoot': wabRoot
+      });
+      this.app.options['skip-install'] = true;
+      this.app.run({}, function () {
+        done();
+      });
+    }.bind(this));
+  });
+
+  it('does not create dotfiles or Gruntfile', function () {
+    var expected = [
+      '.jshintrc',
+      '.editorconfig',
+      'Gruntfile.js'
+    ];
+    helpers.assertNoFile(expected);
+  });
+});


### PR DESCRIPTION
don't create package.json from template
use npmInstall() to install dependencies
package.json not required for successful install,
but is needed for --save-dev to work, so checks if package.json exists
if not ask if user wants to abort and run `npm init` first

also removes prompt for Author and resolves #39 