### PR TITLE
Populate author and license based on package.json

### DIFF
--- a/test/test-widget.js
+++ b/test/test-widget.js
@@ -1,11 +1,19 @@
-/*global describe, beforeEach, it */
+/*global describe, before, beforeEach, it */
 'use strict';
 var path = require('path');
 var helpers = require('yeoman-generator').test;
+var fs = require('fs');
+
+var wabRoot = path.join(__dirname, 'temp');
+var filePath = 'package.json';
+var testAuthorName = 'Barney Rubble';
+var testAuthorEmail = 'b@rubble.com';
+var testAuthorUrl = 'http://barnyrubble.tumblr.com';
+var testLicense = 'Apache-2.0';
 
 describe('esri-appbuilder-js:widget subgenerator', function () {
   beforeEach(function (done) {
-    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+    helpers.testDirectory(wabRoot, function (err) {
       if (err) {
         return done(err);
       }
@@ -688,6 +696,200 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
 
     it('should set hasSettingStyle to true in manifest', function() {
       helpers.assertFileContent('widgets/TestWidget/manifest.json', /"hasSettingStyle": true/);
+    });
+  });
+
+  describe('when creating a widget that has a package.json', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":"' + testAuthorName + '", "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has author name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "' + testAuthorName + '",'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+  describe('when creating a widget that has a package.json with author object - name only', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":{"name":"' + testAuthorName + '"}, "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has author name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "' + testAuthorName + '",'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+  describe('when creating a widget that has a package.json with author object - author and email', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":{"name":"' + testAuthorName + '", "email":"' + testAuthorEmail + '"}, "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has author name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "' + testAuthorName + ' <' + testAuthorEmail + '>",'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+    describe('when creating a widget that has a package.json with author object but no name property', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":{"url":"' + testAuthorUrl + '"}, "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has blank author in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "",'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+  describe('when creating a widget that has a package.json with author object - author and url', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":{"name":"' + testAuthorName + '", "url":"' + testAuthorUrl + '"}, "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has author name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "' + testAuthorName + ' \\(' + testAuthorUrl + '\\)"'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+  describe('when creating a widget that has a package.json with author object - author, email, url', function() {
+    beforeEach(function(done) {
+      fs.writeFileSync(filePath, '{"author":{"name":"' + testAuthorName + '", "email":"' + testAuthorEmail + '", "url":"' + testAuthorUrl + '"}, "license":"' + testLicense + '"}');
+
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has author name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "' + testAuthorName + ' <' + testAuthorEmail + '> \\(' + testAuthorUrl + '\\)"'));
+    });
+
+    it('has license name in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "' + testLicense + '",'));
+    });
+  });
+
+  describe('when creating a widget that does not have a package.json', function() {
+    beforeEach(function(done) {
+      helpers.mockPrompt(this.widget, {
+        widgetName: 'TestWidget',
+        widgetTitle: 'Test Widget',
+        description: 'A test widget.',
+        path: 'widgets',
+        baseClass: 'test-widget',
+        features: [],
+        hasSettingPage: false,
+        settingsFeatures: [  ]
+      });
+      this.widget.run({}, function () {
+        done();
+      });
+    });
+
+    it('has blank author in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"author": "",'));
+    });
+
+    it('has blank license in manifest.json', function (/*done*/) {
+      helpers.assertFileContent('widgets/TestWidget/manifest.json', new RegExp('"license": "",'));
     });
   });
 

--- a/widget/index.js
+++ b/widget/index.js
@@ -2,6 +2,7 @@
 var path = require('path');
 var yeoman = require('yeoman-generator');
 var chalk = require('chalk');
+var utils = require('./utils');
 
 var WidgetGenerator = yeoman.generators.Base.extend({
   askFor: function () {
@@ -121,6 +122,11 @@ var WidgetGenerator = yeoman.generators.Base.extend({
       this.widgetName = props.widgetName;
       this.widgetTitle = props.widgetTitle;
       this.description = props.description;
+
+      // properties that we need to get from the package json, if it exists:
+      this.author = utils.authorToString(utils.getPackageInfo('author'));
+      this.license = (utils.getPackageInfo('license') !== false ? utils.getPackageInfo('license') : '');
+
       // TODO: get from prompt once the WAB supports 3D
       this.is2d = true;
       this.is3d = false;

--- a/widget/templates/_manifest.json
+++ b/widget/templates/_manifest.json
@@ -6,10 +6,10 @@
   "platform": "HTML",
   "version": "0.0.1",
   "wabVersion": "1.4",
-  "author": "TODO: your name here",
+  "author": "<%= author %>",
   "description": "<%= description %>",
   "copyright": "",
-  "license": "http://www.apache.org/licenses/LICENSE-2.0",
+  "license": "<%= license %>",
   "properties": {
     "inPanel": <%= inPanel %>,
     "hasLocale": <%= hasLocale %>,

--- a/widget/utils.js
+++ b/widget/utils.js
@@ -1,0 +1,43 @@
+'use strict';
+var fs = require('fs');
+
+var authorToString = function(inStringOrObject) {
+  if (inStringOrObject) {
+    if (typeof inStringOrObject === 'object') {
+      if(inStringOrObject.hasOwnProperty('name')) {
+        var nameString = inStringOrObject.name;
+        if (inStringOrObject.hasOwnProperty('email')) {
+          nameString += ' <' + inStringOrObject.email + '>';
+        }
+        if (inStringOrObject.hasOwnProperty('url')) {
+          nameString += ' (' + inStringOrObject.url + ')';
+        }
+        return nameString;
+      } else {
+        return '';
+      }
+    } else {
+      return inStringOrObject;
+    }
+  } else {
+    return '';
+  }
+};
+module.exports.authorToString = authorToString;
+
+
+var getPackageInfo = function(packageProperty) {
+  try {
+    var packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    if(packageJson.hasOwnProperty(packageProperty)) {
+      return packageJson[packageProperty];
+    } else {
+      // does not have the property we are looking for
+      return false;
+    }
+  } catch (e) {
+    // no package.json
+    return false;
+  }
+};
+module.exports.getPackageInfo = getPackageInfo;


### PR DESCRIPTION
Code and tests to have the widget generator populate the `author` and `license` properties of the `manifest.json` file from the project's `package.json`, if it exists.

Resolves #4