### PR TITLE
default to es5, update jshintrc, add ES2015/lint info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The app generator installs and configures the [grunt tasks](#running-the-grunt-t
 
 **NOTE** A package.json file is not *required* but it allows the generator to save your dependencies in case you or other developers need to (re)install them later without running the generator.
 
+
 #### Widget Generator
 
 Scaffolds out the files needed to create a new custom widget.
@@ -68,6 +69,7 @@ Scaffolds out the files needed to create a new custom widget.
 |Settings template (HTML) file|Will your settings page require a template file?|Yes|
 |Settings locale (i18n) file|Will your settings page require a locale file?|Yes|
 |Settings style (CSS) file|Will your settings page require a style file?|Yes|
+|Which JavaScript syntax version would you like to develop in?|Will widget and settings JavaScript files use ES2015 or ES5?|ES5|
 
 Taking the default values for the prompts will generate the following output under the `widgets` folder:
 
@@ -130,6 +132,35 @@ grunt
 
 This will copy over any files that haven't already been copied over, and then start watching all files under the widgets folder for changes and re-copy the files to the Web AppBuilder's folders.
 
+### Linting Your Code
+
+By default the app generator scaffolds out [Esri's standard jshint configuration file](https://github.com/Esri/jsapi-resources/tree/master/jshint). This should work well for ES5 files, however, it is not configured for ES2015 syntax. If you are going to use ES2015 syntax, we recommend that you use [semistandard][semistandard].
+
+1) Install semistandard:
+```bash
+npm install -g semistandard
+```
+
+2) Below is a sample configuration you can add to your package.json:
+```json
+  "semistandard": {
+    "globals": [
+      "define"
+    ],
+    "ignore": [
+      "Gruntfile.js",
+      "**/dist/**/*.js"
+    ]
+  }
+```
+
+3) Validate your code:
+```bash
+semistandard
+```
+
+See the [semistandard docs][semistandard] for more information.
+
 ## Issues
 
 Find a bug or want to request a new feature?  Please let us know by [submitting an issue](https://github.com/Esri/generator-esri-appbuilder-js/issues).
@@ -157,6 +188,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 A copy of the license is available in the repository's [license.txt](https://raw.githubusercontent.com/Esri/generator-esri-appbuilder-js/master/license.txt) file.
+
+[semistandard]: https://www.npmjs.com/package/semistandard
 
 [](Esri Tags: web AppBuilder yeoman generator node)
 [](Esri Language: JavaScript)

--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -48,12 +48,12 @@
     "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
                                  // (ex: `for each`, multiple try/catch, function expression…)
     "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
-    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
-    "funcscope"     : true,      // true: Tolerate defining variables inside control statements ** Other variable checks keep use from abusing this **
+    "expr"          : true,      // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : true,      // true: Tolerate defining variables inside control statements ** Other variable checks keep us from abusing this **
     "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
     "iterator"      : false,     // true: Tolerate using the `__iterator__` property
     "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
-    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxbreak"      : true,      // true: Tolerate possibly unsafe line breakings
     "laxcomma"      : false,     // true: Tolerate comma-first style coding
     "loopfunc"      : true,      // true: Tolerate functions being defined in loops ** Almost required in some callback & promise style code **
     "multistr"      : false,     // true: Tolerate multi-line strings

--- a/test/test-widget.js
+++ b/test/test-widget.js
@@ -82,8 +82,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
     });
 
     it('has title/description in nls', function() {
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: "Test Widget"/);
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: "A test widget\."/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: 'Test Widget'/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: 'A test widget\.'/);
     });
 
   });
@@ -155,8 +155,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
     });
 
     it('has title/description in nls', function() {
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: "Test Widget"/);
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: "A test widget\."/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: 'Test Widget'/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: 'A test widget\.'/);
     });
 
   });
@@ -296,8 +296,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
     });
 
     it('has title/description in nls', function() {
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: "Test Widget"/);
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: "A test widget\."/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: 'Test Widget'/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: 'A test widget\.'/);
     });
 
   });
@@ -365,8 +365,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
     });
 
     it('has title/description in nls', function() {
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: "Test Widget"/);
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: "A test widget\."/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: 'Test Widget'/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: 'A test widget\.'/);
     });
 
   });
@@ -431,8 +431,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
     });
 
     it('has title/description in nls', function() {
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: "Test Widget"/);
-      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: "A test widget\."/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /widgetTitle: 'Test Widget'/);
+      assert.fileContent('widgets/TestWidget/nls/strings.js', /description: 'A test widget\.'/);
     });
 
   });

--- a/widget/index.js
+++ b/widget/index.js
@@ -119,7 +119,7 @@ var WidgetGenerator = Base.extend({
       name: 'jsVersion',
       type: 'list',
       message: 'Which JavaScript  syntax version would you like to develop in?',
-      choices: [ 'ES2015', 'ES5']
+      choices: ['ES5', 'ES2015']
     }];
 
     this.prompt(prompts, function (props) {

--- a/widget/templates/_Widget_ES2015.js
+++ b/widget/templates/_Widget_ES2015.js
@@ -1,7 +1,7 @@
 import declare from 'dojo/_base/declare';
 import BaseWidget from 'jimu/BaseWidget';
 
-//To create a widget, you need to derive from BaseWidget.
+// To create a widget, you need to derive from BaseWidget.
 export default declare([BaseWidget], {
 
   // Custom widget code goes here
@@ -10,8 +10,8 @@ export default declare([BaseWidget], {
 
   // add additional properties here
 
-  //methods to communication with app container:
-  postCreate() {
+  // methods to communication with app container:
+  postCreate () {
     this.inherited(arguments);
     console.log('<%= widgetName %>::postCreate');
   }

--- a/widget/templates/nls/_strings.js
+++ b/widget/templates/nls/_strings.js
@@ -1,7 +1,7 @@
 define({
   root: {
-    widgetTitle: "<%= widgetTitle %>" ,
-    description: "<%= description %>"
+    widgetTitle: '<%= widgetTitle %>',
+    description: '<%= description %>'
   }
   // add supported locales below:
   // , "zh-cn": true

--- a/widget/templates/setting/_Setting_ES2015.js
+++ b/widget/templates/setting/_Setting_ES2015.js
@@ -1,37 +1,20 @@
-///////////////////////////////////////////////////////////////////////////
-// Copyright © 2014 Esri. All Rights Reserved.
-//
-// Licensed under the Apache License Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-///////////////////////////////////////////////////////////////////////////
-
 import declare from 'dojo/_base/declare';
 import BaseWidgetSetting from 'jimu/BaseWidgetSetting';
-
 
 export default declare([BaseWidgetSetting], {
   baseClass: '<%= baseClass %>-setting',
 
-  postCreate() {
-    //the config object is passed in
+  postCreate () {
+    // the config object is passed in
     this.setConfig(this.config);
   },
 
-  setConfig(config) {
+  setConfig (config) {
     this.textNode.value = config.serviceUrl;
   },
 
-  getConfig() {
-    //WAB will get config object through this method
+  getConfig () {
+    // WAB will get config object through this method
     return {
       serviceUrl: this.textNode.value
     };

--- a/widget/templates/setting/_Setting_ES5.js
+++ b/widget/templates/setting/_Setting_ES5.js
@@ -1,19 +1,3 @@
-///////////////////////////////////////////////////////////////////////////
-// Copyright © 2014 Esri. All Rights Reserved.
-//
-// Licensed under the Apache License Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//    http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-///////////////////////////////////////////////////////////////////////////
-
 define([
   'dojo/_base/declare',
   'jimu/BaseWidgetSetting'

--- a/widget/templates/setting/nls/_strings.js
+++ b/widget/templates/setting/nls/_strings.js
@@ -1,5 +1,5 @@
 define({
   root: ({
-    serviceUrl: "Set service url:"
+    serviceUrl: 'Set service url:'
   })
 });


### PR DESCRIPTION
resolves #56 

update to latest JSAPI .jshintrc

output, esp es6, passes semistandard

also removed Esri comment code block from Setting.js

default to ES5

updated README w/ ES5 and jshint/semistandard info