### PR TITLE
fixed babel-core requirement issue

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -340,6 +340,7 @@ module.exports = Generator.extend({
       'grunt-contrib-watch',
       'grunt-sync',
       'grunt-babel',
+      'babel-core',
       'grunt-contrib-clean',
       'grunt-contrib-copy',
       'grunt-sass'


### PR DESCRIPTION
... because `babel-core` is no a peerDependency https://github.com/babel/grunt-babel/releases/tag/v7.0.0

resolves #90
