### PR TITLE
TypeScript update

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -322,6 +322,10 @@ module.exports = class extends Generator {
         this.templatePath('tsconfig'),
         this.destinationPath('tsconfig.json')
       );
+      this.fs.copyTpl(
+        this.templatePath('tslint'),
+        this.destinationPath('tslint.json')
+      );
     } else {
       this.fs.copyTpl(
         this.templatePath('babelrc'),
@@ -351,22 +355,22 @@ module.exports = class extends Generator {
 
     // we install different sets of packages depending on TypeScript or not:
     var dependencies = [
-      'grunt',
-      'grunt-contrib-clean',
-      'grunt-contrib-copy',
+      'grunt@^1.0.3',
+      'grunt-contrib-clean@^2.0.0',
+      'grunt-contrib-copy@^1.0.0',
       'node-sass',
-      'grunt-sass@3.0.1',
+      'grunt-sass@^3.0.1',
       'grunt-sync@^0.8.0',
-      'grunt-contrib-watch',
+      'grunt-contrib-watch@^1.1.0',
       'esri-wab-build@^1.0.1'
     ];
 
     if(this.jsVersion === 'TypeScript') {
       dependencies = dependencies.concat([
-        'dojo-typings',
+        'dojo-typings@^1.11.7',
         'grunt-contrib-connect',
-        'grunt-ts',
-        'typescript@3.0.3'
+        'grunt-ts@^6.0.0-beta.16',
+        'typescript@^3.1.1'
       ]);
       // 3D vs 2D we need to install a different declarations file:
       if (this.widgetsType === 'is3d') {

--- a/app/templates/tsconfig
+++ b/app/templates/tsconfig
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "amd",
     "moduleResolution": "classic",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "jsx": "react",
     "jsxFactory": "tsx",
     "target": "es5",
@@ -13,10 +13,11 @@
     "types": [ "arcgis-js-api", "dojo-typings"],
     "rootDir": "widgets",
     "outDir": "dist/Widgets",
-    "noImplicitUseStrict":true,
+    "noImplicitUseStrict": true,
     "lib": ["dom", "es5", "scripthost", "es2015.promise"],
     "inlineSources": true,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "esModuleInterop": true
   },
   
   "include": [

--- a/app/templates/tslint
+++ b/app/templates/tslint
@@ -1,0 +1,10 @@
+
+{
+  "extends": "tslint:recommended",
+  "rules": {
+      "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+      "no-console": [false]
+  },
+  "jsRules": {
+  }
+}

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -285,6 +285,7 @@ describe('esri-appbuilder-js:app - TypeScript', function () {
     var expected = [
       '.editorconfig',
       'tsconfig.json',
+      'tslint.json',
       '.yo-rc.json'
     ];
     assert.file(expected);

--- a/test/test-widget.js
+++ b/test/test-widget.js
@@ -968,8 +968,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
       .on('end', done);
     });
 
-    it('has wabVersion set to 2.7', function (/*done*/) {
-      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.7",/);
+    it('has wabVersion set to 2.9', function (/*done*/) {
+      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.9",/);
     });
 
     it('has platform set to HTML', function (/*done*/) {
@@ -1005,8 +1005,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
       .on('end', done);
     });
 
-    it('has wabVersion set to 2.7', function (/*done*/) {
-      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.7"/);
+    it('has wabVersion set to 2.9', function (/*done*/) {
+      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.9"/);
     });
 
     it('has platform set to HTML', function (/*done*/) {
@@ -1041,8 +1041,8 @@ describe('esri-appbuilder-js:widget subgenerator', function () {
       .on('end', done);
     });
 
-    it('has wabVersion set to 2.7', function (/*done*/) {
-      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.7"/);
+    it('has wabVersion set to 2.9', function (/*done*/) {
+      assert.fileContent('widgets/TestWidget/manifest.json', /"wabVersion": "2.9"/);
     });
 
     it('has platform set to HTML3D', function (/*done*/) {

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,10 @@
+
+{
+  "extends": "tslint:recommended",
+  "rules": {
+      "quotemark": [true, "single", "avoid-escape", "avoid-template"],
+      "no-console": [false]
+  },
+  "jsRules": {
+  }
+}

--- a/widget/index.js
+++ b/widget/index.js
@@ -131,7 +131,7 @@ module.exports = class extends Generator {
       this.jsVersion = this.config.get('jsVersion');
       this.is2d = (this.widgetsType === 'is2d');
       this.is3d = (this.widgetsType === 'is3d');
-      this.wabVersion = '2.7';
+      this.wabVersion = '2.9';
 
       if (this.is3d) {
         this.platform = 'HTML3D';

--- a/widget/templates/_Widget_2d.ts
+++ b/widget/templates/_Widget_2d.ts
@@ -1,66 +1,62 @@
 // jIMU (WAB) imports:
-
 /// <amd-dependency path="jimu/BaseWidget" name="BaseWidget" />
 declare var BaseWidget: any; // there is no ts definition of BaseWidget (yet!)
-
 // declareDecorator - to enable us to export this module with Dojo's "declare()" syntax so WAB can load it:
-import declare from "./support/declareDecorator";
+import declare from './support/declareDecorator';
 
 // esri imports:
-import esri = require("esri");
-import EsriMap = require("esri/map");
+import EsriMap from 'esri/map';
 
-// dojo imports: (example below)
+// dojo imports:
 // import * as on from 'dojo/on';
 
 interface IConfig {
   serviceUrl: string;
 }
 interface IWidget {
+  baseClass: string;
   config?: IConfig;
-  baseClass: String;
-  map: EsriMap;
-  postCreate: Function;
 }
 
 @declare(BaseWidget)
 class Widget implements IWidget {
-  baseClass = "<%= baseClass %>";
+  public baseClass: string = '<%= baseClass %>';
+  public config: IConfig;
 
-  map: EsriMap;
+  private map: EsriMap;
 
-  postCreate(args: any): void {
-    let self: any = this;
+  private postCreate(args: any): void {
+    const self: any = this;
     self.inherited(arguments);
-    console.log("<%= widgetName %>::postCreate");
+    console.log('<%= widgetName %>::postCreate');
   }
-  // startup() {
+  // private startup(): void {
   //   let self: any = this;
   //   self.inherited(arguments);
   //   console.log('<%= widgetName %>::startup');
   // };
-  // onOpen() {
+  // private onOpen(): void {
   //   console.log('<%= widgetName %>::onOpen');
   // };
-  // onClose(){
+  // private onClose(): void {
   //   console.log('<%= widgetName %>::onClose');
   // };
-  // onMinimize(){
+  // private onMinimize(): void {
   //   console.log('<%= widgetName %>::onMinimize');
   // };
-  // onMaximize(){
+  // private onMaximize(): void {
   //   console.log('<%= widgetName %>::onMaximize');
   // };
-  // onSignIn(credential){
+  // private onSignIn(credential): void {
   //   console.log('<%= widgetName %>::onSignIn', credential);
   // };
-  // onSignOut(){
+  // private onSignOut(): void {
   //   console.log('<%= widgetName %>::onSignOut');
   // };
-  // onPositionChange(){
+  // private onPositionChange(): void {
   //   console.log('<%= widgetName %>::onPositionChange');
   // };
-  // resize(){
+  // private resize(): void {
   //   console.log('<%= widgetName %>::resize');
   // };
 }

--- a/widget/templates/_Widget_3d.ts
+++ b/widget/templates/_Widget_3d.ts
@@ -1,13 +1,13 @@
-// jIMU (WAB) imports:
+// JIMU (WAB) imports:
 
 /// <amd-dependency path="jimu/BaseWidget" name="BaseWidget" />
 declare var BaseWidget: any; // there is no ts definition of BaseWidget (yet!)
 
 // declareDecorator - to enable us to export this module with Dojo's "declare()" syntax so WAB can load it:
-import declare from "./support/declareDecorator";
+import declare from './support/declareDecorator';
 
-// esri imports:
-import SceneView = require("esri/views/SceneView");
+// Esri imports:
+import SceneView from 'esri/views/SceneView';
 
 // dojo imports: (example below)
 // import * as on from 'dojo/on';
@@ -16,50 +16,49 @@ interface IConfig {
   serviceUrl: string;
 }
 interface IWidget {
+  baseClass: string;
   config?: IConfig;
-  baseClass: String;
-  map: EsriMap;
-  postCreate: Function;
 }
 
 @declare(BaseWidget)
 class Widget implements IWidget {
-  baseClass = "<%= baseClass %>";
+  public baseClass: string = '<%= baseClass %>';
+  public config: IConfig;
 
-  sceneView: SceneView;
+  private sceneView: SceneView;
 
-  postCreate(args: any): void {
-    let self: any = this;
+  private postCreate(args: any) {
+    const self: any = this;
     self.inherited(arguments);
-    console.log("<%= widgetName %>::postCreate");
+    console.log('<%= widgetName %>::postCreate');
   }
-  // startup() {
+  // private startup(): void {
   //   let self: any = this;
   //   self.inherited(arguments);
   //   console.log('<%= widgetName %>::startup');
   // };
-  // onOpen() {
+  // private onOpen(): void {
   //   console.log('<%= widgetName %>::onOpen');
   // };
-  // onClose(){
+  // private onClose(): void {
   //   console.log('<%= widgetName %>::onClose');
   // };
-  // onMinimize(){
+  // private onMinimize(): void {
   //   console.log('<%= widgetName %>::onMinimize');
   // };
-  // onMaximize(){
+  // private onMaximize(): void {
   //   console.log('<%= widgetName %>::onMaximize');
   // };
-  // onSignIn(credential){
+  // private onSignIn(credential): void {
   //   console.log('<%= widgetName %>::onSignIn', credential);
   // };
-  // onSignOut(){
+  // private onSignOut(): void {
   //   console.log('<%= widgetName %>::onSignOut');
   // };
-  // onPositionChange(){
+  // private onPositionChange(): void {
   //   console.log('<%= widgetName %>::onPositionChange');
   // };
-  // resize(){
+  // private resize(): void {
   //   console.log('<%= widgetName %>::resize');
   // };
 

--- a/widget/templates/setting/_Setting.ts
+++ b/widget/templates/setting/_Setting.ts
@@ -4,36 +4,38 @@
 declare var BaseWidgetSetting: any; // there is no ts definition of BaseWidgetSetting (yet!)
 
 // DeclareDecorator - to enable us to export this module with Dojo's "declare()" syntax so WAB can load it:
-import declare from "../support/declareDecorator";
+import declare from '../support/declareDecorator';
 
-interface Config {
-  serviceUrl: string
+interface IConfig {
+  serviceUrl: string;
 }
-interface Setting {
-  textNode?: HTMLInputElement
-  config?: Config
+interface ISetting {
+  config?: IConfig;
 }
 
 @declare(BaseWidgetSetting)
-class Setting {
-  baseClass = 'my-widget-setting';
+class Setting implements ISetting {
+  public baseClass: string = '<%= baseClass %>-setting';
+  public config: IConfig;
 
-  postCreate(args: any) {
-    let self: any = this;
+  private textNode: HTMLInputElement;
+
+  private postCreate(args: any): void {
+    const self: any = this;
     self.inherited(arguments);
     this.setConfig(this.config);
-  };
+  }
 
-  setConfig(config: Config) {
+  private setConfig(config: IConfig): void {
     this.textNode.value = config.serviceUrl;
-  };
+  }
 
-  getConfig() {
-    //WAB will get config object through this method
+  private getConfig(): object {
+    // WAB will get config object through this method
     return {
-      serviceUrl: this.textNode.value
+      serviceUrl: this.textNode.value,
     };
-  };
-};
+  }
+}
 
 export = Setting;

--- a/widget/templates/support/declareDecorator.ts
+++ b/widget/templates/support/declareDecorator.ts
@@ -1,12 +1,12 @@
-import * as declare from 'dojo/_base/declare';
+import declare = require('dojo/_base/declare');
 
 /**
  * A decorator that converts a TypeScript class into a declare constructor.
  * This allows declare constructors to be defined as classes, which nicely
  * hides away the `declare([], {})` boilerplate.
  */
-export default function (... mixins: Object[]) {
-	return function (target: Function) {
+export default function(... mixins: Object[]): Function {
+	return function(target: Function): Function {
 		return declare(mixins, target.prototype);
 	};
 }


### PR DESCRIPTION
- Updated `tsconfig` template to use `esModuleInterop` so `require()` syntax is not needed for including modules anymore.
- Updated WAB version
- Updated `Widget.ts` template files to follow more modern patterns
- Updated to latest TypeScript (v3.1.1)