### PR TITLE
fixed grunt-babel versions at 7

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -383,9 +383,9 @@ module.exports = class extends Generator {
       dependencies = dependencies.concat([
       'babel-plugin-transform-es2015-modules-simple-amd',
       'babel-preset-es2015-without-strict',
-        'babel-preset-stage-0',
-        'grunt-babel',
-        'babel-core'
+      'babel-preset-stage-0',
+      'grunt-babel@~7.0.0',
+      'babel-core@~6.26.3'
       ]);
     }
 


### PR DESCRIPTION
added specific versions for `grunt-babel` and `babel-core` to avoid errors from the recently-relased grunt-babel 8. #129