### PR TITLE
tsconfig to compile themes

### DIFF
--- a/app/templates/tsconfig
+++ b/app/templates/tsconfig
@@ -11,8 +11,8 @@
     "preserveConstEnums": true,
     "suppressImplicitAnyIndexErrors": true,
     "types": [ "arcgis-js-api", "dojo-typings"],
-    "rootDir": "widgets",
-    "outDir": "dist/Widgets",
+    "rootDir": "./",
+    "outDir": "dist",
     "noImplicitUseStrict": true,
     "lib": ["dom", "es5", "scripthost", "es2015.promise"],
     "inlineSources": true,
@@ -21,6 +21,7 @@
   },
   
   "include": [
+    "themes/**/*.ts",
     "widgets/**/*.ts"
   ],
   "exclude": [


### PR DESCRIPTION
Updated ts config so theme widgets can be created. Prior to this update typescript would only compile widgets developed in the widgets folder. The update now looks for any typescript files in the themes folder.  

Sorry I couldn't think of any tests to include as its just a change to the tsconfig file (which we already check for the existence of)